### PR TITLE
ci: bump codecov-action to v6 for Node 24 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Upload code coverage to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v4  # <-- New action to upload coverage file
+        uses: codecov/codecov-action@v6  # <-- New action to upload coverage file
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           # The action will automatically search for common coverage files (e.g., coverage.xml)


### PR DESCRIPTION
## Ce

Bump `codecov/codecov-action` `v4`/`v5` → `v6` în `.github/workflows/test.yml`.

## De ce

`codecov-action` v4/v5 pinuiește intern `actions/github-script@v7.0.1`, care rulează pe Node 20 — deprecat. GitHub Actions forțează Node 24 implicit de la 16-06-2026 și scoate Node 20 de pe runnere pe 16-09-2026. `codecov-action@v6` urcă github-script la v8 (Node 24), eliminând warning-ul de deprecare.

Nu necesită config nou: `CODECOV_TOKEN` e deja folosit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)