### PR TITLE
[FIX] Apps Store: lizibilitate descriere (CSS)

### DIFF
--- a/deltatech_obyc/static/description/index.html
+++ b/deltatech_obyc/static/description/index.html
@@ -360,7 +360,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-obyc-account-determination"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-obyc-account-determination"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_stock_valuation/static/description/index.html
+++ b/deltatech_stock_valuation/static/description/index.html
@@ -360,7 +360,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="product-valuation"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="product-valuation"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_valuation_area/static/description/index.html
+++ b/deltatech_valuation_area/static/description/index.html
@@ -360,7 +360,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-stock-valuation-area"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-stock-valuation-area"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_valuation_report/static/description/index.html
+++ b/deltatech_valuation_report/static/description/index.html
@@ -360,7 +360,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="product-valuation-check-report"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="product-valuation-check-report"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/scripts/tb_skin_index.py
+++ b/scripts/tb_skin_index.py
@@ -76,7 +76,7 @@ FONT = "'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif"
 # NB: gradient/`background` shorthand sunt tăiate de store → doar `background-color`.
 # ----------------------------------------------------------------------------- #
 
-WRAP_OPEN = f'<div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:{FONT};">'
+WRAP_OPEN = f'<div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:{FONT};color:#1f2d27;">'
 
 HERO = """%(marker)s
 <div style="background-color:%(primary)s;color:#ffffff;border-radius:20px;


### PR DESCRIPTION
Odoo Apps Store taie tag-ul `<style>` din `index.html`. Skin-ul se baza pe culoare moștenită pentru corpul textului → pe store textul ieșea gri, ilizibil pe fundal alb (vezi Sale Margin).

**Fix:**
- Culoare ink explicită inline (`color:#1f2d27`) pe wrapperul de conținut (`WRAP_OPEN`), de unde tot corpul o moștenește.
- Re-skin la **v4** pentru modulele rămase pe v2 (aveau corpul nestilizat + shields vizibile pe store).

Template-ul `scripts/tb_skin_index.py` e actualizat pentru regenerări viitoare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)